### PR TITLE
Syntax error in import with Python 3.10.10

### DIFF
--- a/brownian_motion_generator/__init__.py
+++ b/brownian_motion_generator/__init__.py
@@ -1,1 +1,2 @@
-import .brownian_motion_generator
+from __future__ import absolute_import
+from . import brownian_motion_generator

--- a/brownian_motion_generator/__init__.py
+++ b/brownian_motion_generator/__init__.py
@@ -1,2 +1,1 @@
-from __future__ import absolute_import
 from . import brownian_motion_generator


### PR DESCRIPTION
This PR updates the import statement for `brownian_motion_generator` to improve compatibility between Python 2 and Python 3. The changes are as follows:

Previous import statement:
```
import .brownian_motion_generator
```

Updated import statement:

```
from . import brownian_motion_generator
```
Reason for the changes:

The previous import statement was throwing a syntax error under python 3.10.10. 

![image](https://user-images.githubusercontent.com/34455148/233692040-d729f323-b7a2-4759-9c85-5effa12812aa.png)
